### PR TITLE
add pre-/post- up/down script hooks for device

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ inv request-and-connect-tunnel      # there are also separate request and connec
 ```
 This will print both a tunnel ID and a preshared key. These should be transmitted to the `admin` out of band, likely through a typical support channel.
 
+The `device` context supports a configuration file at `/etc/support_tunnel/config.ini`. An example config with comments is available at `device/example_config.ini`.
+
 ### `admin`
 
 On your `admin`, you probably need to log in to a cloud provider so you can start and configure instances. For Micro-Nova, this is Google Cloud Platform. Install the [`gcloud` utility](https://cloud.google.com/sdk/docs/install-sdk) and run these steps:

--- a/device/example_config.ini
+++ b/device/example_config.ini
@@ -1,0 +1,13 @@
+[device]
+api=https://support-tunnel.prod.gcp.amplipi.com/v1/
+debug=false
+# The below lines can have these variables templated in the invocation
+# {id}    : the support tunnel id
+# {iface} : the interface that is going up/down
+# {ip}    : the ip address of the wireguard interface
+# {net}   : the network in CIDR notation
+# {user}  : the support user being created
+#pre-up-script=
+#post-up-script=
+#pre-down-script=
+#post-down-script=


### PR DESCRIPTION
This PR adds pre-/post- interface up/down scripts, as helpers for network configuration. This was necessitated by https://github.com/micro-nova/AmpliPi/issues/826 . In addition to this, support for a basic configuration file was added. (I would have used toml, but that was only introduced in Python 3.11 - we currently use 3.8 on our appliances.)

I know you haven't seen much of this repo, but I'd like to begin putting these changes through for review and it makes sense to start now.