### PR TITLE
Pin bcrypt==4.1.3, cryptography==42.0.8 for buster compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,10 @@ sqlmodel
 tenacity
 SQLAlchemy
 python-jose
+bcrypt==4.1.3
 systemd-python
 wireguard-tools
 google-cloud-compute
+cryptography==42.0.8
 google-cloud-secret-manager
 cloud-sql-python-connector[pymysql]


### PR DESCRIPTION
This PR pins `bcrypt==4.1.3` to permit installation on Debian Buster. The upstream bcrypt reference is https://github.com/pyca/bcrypt/issues/845 ; they believe this is due to an ancient `pip`, and my brief test on bookworm indicates they're right.

Additionally, this PR pins cryptography==42.0.8. This is also [due to a breaking change](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst), an explicit deprecation of our OpenSSL version.

These two combined resolve https://github.com/micro-nova/AmpliPi/issues/841 . As far as AmpliPi goes, https://github.com/micro-nova/AmpliPi/issues/599 unblocks us installing a new OS on appliances in the field, which is spec'd for Soon :tm: (and couldn't come sooner.) It will be glorious when we we're on bullseye (or greater!) and can more explicitly manage minimum versions in the field.