### PR TITLE
pin sqlmodel==0.0.19 because of changes in UUID handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,13 +9,13 @@ uvicorn
 pydantic
 pyroute2
 requests
-sqlmodel
 tenacity
 SQLAlchemy
 python-jose
 bcrypt==4.1.3
 systemd-python
 wireguard-tools
+sqlmodel==0.0.19
 google-cloud-compute
 cryptography==42.0.8
 google-cloud-secret-manager


### PR DESCRIPTION
This PR pins sqlmodel to 0.0.19. [sqlmodel introduced much better UUID handling in 0.0.20](https://sqlmodel.tiangolo.com/advanced/uuid/), but implementing their methodology will require more testing than this simple change. This chnage fixes the `device` context cleaning up tunnel resources, which presents like:

```
(venv) pi@amplipi:/opt/support_tunnel $ inv stop [snipped tunnel id]
Traceback (most recent call last):                                                                                                 
  File "/opt/support_tunnel/venv/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1816, in _execute_context                dialect, self, conn, execution_options, *args, **kw                                                                            
  File "/opt/support_tunnel/venv/lib/python3.7/site-packages/sqlalchemy/engine/default.py", line 1463, in _init_compiled               for key in positiontup                                                                                                         
  File "/opt/support_tunnel/venv/lib/python3.7/site-packages/sqlalchemy/engine/default.py", line 1463, in <listcomp>                   for key in positiontup                                                                                                         
  File "/opt/support_tunnel/venv/lib/python3.7/site-packages/sqlalchemy/sql/sqltypes.py", line 3608, in process                        value = value.hex                                                                                                              
AttributeError: 'str' object has no attribute 'hex'          
```

I also filed #25 for tracking that future work.