### PR TITLE
support user accounts should not be locked

### DIFF
--- a/common/util.py
+++ b/common/util.py
@@ -59,7 +59,7 @@ def create_user(c: Union[LocalContext, Connection], username: Optional[str] = No
     # Because we have an explicit dependency on the specified group existing, we call create_group() here.
     create_group(c)
 
-    c.run(f"sudo useradd -g {group_name} -s $(which bash) -m {name}")
+    c.run(f"sudo useradd -g {group_name} -s $(which bash) -p '*' -m {name}")
 
     return SupportUser(username=name, group=group_name)
 


### PR DESCRIPTION
This is a slightly more correct instantiation of support user accounts. Without a password specified, `useradd` makes the password field `!`, which locks the account - however, `UsePAM` in `/etc/sshd_config` ignores that and allows users to log in anyways if some other auth mechanism is used. In our default AmpliPi `sshd_config` this is not a problem because we have `UsePAM`. However, a user ships their own custom and very reasonable sshd_config that omits `UsePAM`, which prevented the support tunnel user from being able to authenticate. This PR fixes that.

There are more [details here](https://arlimus.github.io/articles/usepam/) ([archive.org](https://web.archive.org/web/20240627131308/https://arlimus.github.io/articles/usepam/)).