### PR TITLE
test against more versions of Python in PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: Ruff
+name: PR checks
 on: 
   pull_request:
 jobs:
@@ -10,8 +10,15 @@ jobs:
   mypy:
     needs: ruff
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
       - uses: actions/checkout@v3
+      - run: sudo apt install libsystemd-dev
       - run: pip install -r requirements.txt
-      - run: pip install mypy
-      - run: mypy --install-types --non-interactive --explicit-package-bases --disable-error-code import-untyped .
+      - run: pip install mypy==1.4.1  # 1.4.1 is the last version to support Python 3.7, which we run on AmpliPi
+      - run: mypy --install-types --non-interactive --explicit-package-bases --ignore-missing-imports .

--- a/admin/cloud.py
+++ b/admin/cloud.py
@@ -1,6 +1,7 @@
 import logging
 
 from os import getenv
+from typing import List
 from ipaddress import IPv4Address
 
 from pydantic import UUID4
@@ -34,7 +35,7 @@ def get_ts_instance(tunnel_id: UUID4) -> compute_v1.Instance:
     instance_client = compute_v1.InstancesClient()
     return instance_client.get(project=PROJECT_ID, zone=ZONE, instance=f"{INSTANCE_NAME_PREFIX}-{tunnel_id}")
 
-def list_ts_instances() -> list[compute_v1.Instance]:
+def list_ts_instances() -> List[compute_v1.Instance]:
     """ Lists tunnel server instances. At present, it just uses the 
         INSTANCE_NAME_PREFIX to determine if it is a tunnel server.
     """
@@ -53,7 +54,7 @@ def _create_ts_boot_disk() -> compute_v1.AttachedDisk:
     disk.boot = True
     return disk
 
-def _create_ts_network_interfaces() -> list[compute_v1.NetworkInterface]:
+def _create_ts_network_interfaces() -> List[compute_v1.NetworkInterface]:
     """ create a list of network interface descriptions """
     # create network interface & external access configs
     netiface = compute_v1.NetworkInterface()

--- a/api/device.py
+++ b/api/device.py
@@ -50,7 +50,8 @@ def get_tunnel_id(token: str = Depends(oauth2_scheme)) -> UUID:
     try:
         payload = TunnelRequestTokenData(
             **jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGO]))
-        tunnel_id_str = payload.sub.removeprefix("tunnel_id:")
+        prefix_len = len("tunnel_id:")
+        tunnel_id_str = payload.sub[prefix_len:]
         logging.debug(f"tunnel_id_str: {tunnel_id_str}")
         tunnel_id = UUID(hex=tunnel_id_str)
     except JWTError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ systemd-python
 wireguard-tools
 sqlmodel==0.0.19
 google-cloud-compute
-cryptography==42.0.8
+cryptography==43.0.3
 google-cloud-secret-manager
 cloud-sql-python-connector[pymysql]


### PR DESCRIPTION
This PR tests against more version of Python in our GitHub Action. This mainly to guard against someone accidentally merging pyca/cryptography >=44, which deprecates Python 3.7 - yet we use 3.7 in our current AmpliPi product.