### PR TITLE
Pin ubuntu for client support test to have python 3.7

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,5 @@
 name: PR checks
-on: 
+on:
   pull_request:
 jobs:
   ruff:
@@ -9,7 +9,7 @@ jobs:
       - uses: chartboost/ruff-action@v1
   mypy:
     needs: ruff
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # 24.04 does not have Python 3.7
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]


### PR DESCRIPTION
We need this to fix our PR runners in the future or at least until AmpliPi updates its python support.