### PR TITLE
Temporarily revert cryptography until we can add openssl 3 to amplipi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ systemd-python
 wireguard-tools
 sqlmodel==0.0.19
 google-cloud-compute
-cryptography==44.0.1
+cryptography==42.0.8
 google-cloud-secret-manager
 cloud-sql-python-connector[pymysql]


### PR DESCRIPTION
Currently on an up to date AmpliPi with the latest support tunnel. A support tunnel request errors out:

```
/opt/support_tunnel/venv/bin/python3 -m invoke request
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/opt/support_tunnel/venv/lib/python3.7/site-packages/invoke/__main__.py", line 3, in <module>
    program.run()
  File "/opt/support_tunnel/venv/lib/python3.7/site-packages/invoke/program.py", line 387, in run
    self.parse_collection()
  File "/opt/support_tunnel/venv/lib/python3.7/site-packages/invoke/program.py", line 479, in parse_collection
    self.load_collection()
  File "/opt/support_tunnel/venv/lib/python3.7/site-packages/invoke/program.py", line 716, in load_collection
    module, parent = loader.load(coll_name)
  File "/opt/support_tunnel/venv/lib/python3.7/site-packages/invoke/loader.py", line 91, in load
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/opt/support_tunnel/tasks.py", line 3, in <module>
    from device.cli import *
  File "/opt/support_tunnel/device/cli.py", line 23, in <module>
    from common.tunnel import device_ip
  File "/opt/support_tunnel/common/tunnel.py", line 10, in <module>
    from fabric import Connection as FabricConnection
  File "/opt/support_tunnel/venv/lib/python3.7/site-packages/fabric/__init__.py", line 3, in <module>
    from .connection import Config, Connection
  File "/opt/support_tunnel/venv/lib/python3.7/site-packages/fabric/connection.py", line 9, in <module>
    from paramiko.agent import AgentRequestHandler
  File "/opt/support_tunnel/venv/lib/python3.7/site-packages/paramiko/__init__.py", line 22, in <module>
    from paramiko.transport import (
  File "/opt/support_tunnel/venv/lib/python3.7/site-packages/paramiko/transport.py", line 33, in <module>
    from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
  File "/opt/support_tunnel/venv/lib/python3.7/site-packages/cryptography/hazmat/primitives/ciphers/__init__.py", line 11, in <module>
    from cryptography.hazmat.primitives.ciphers.base import (
  File "/opt/support_tunnel/venv/lib/python3.7/site-packages/cryptography/hazmat/primitives/ciphers/base.py", line 10, in <module>
    from cryptography.hazmat.bindings._rust import openssl as rust_openssl
ImportError: libssl.so.3: cannot open shared object file: No such file or directory
```

Reverting cryptography to 42.0.8 fixes this. We will need to figure out a way to include openssl 3 into the next AmpliPi release.